### PR TITLE
Can we keep simple one-line commands in the package.json file so that…

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,11 +1,12 @@
 <html>
   <head>
+    <meta http-equiv="content-type" content="text/html; charset=UTF8">
     <title>Sample App</title>
     <link href="static/choropleth.css">
   </head>
   <body>
     <div id='root'>
     </div>
-    <script src="/static/bundle.min.js"></script>
+    <script src="static/bundle.min.js"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "main": "index.js",
   "scripts": {
     "start": "node server.js",
-    "build_dkan": "./scripts/build_dkan.sh",
-    "build_standalone": "./scripts/build_standalone.sh",
-    "dev_dkan": "./scripts/dev_dkan.sh",
-    "dev_standalone": "./scripts/dev_standalone.sh",
+    "build_dkan": "export MODE='production' && ./node_modules/.bin/webpack --config 'webpack.config.dkan.js'",
+    "build_standalone": "export MODE='production' && ./node_modules/.bin/webpack --config 'webpack.config.standalone.js --progress'",
+    "dev_dkan": "export MODE='development' && ./node_modules/.bin/webpack --config webpack.config.dkan.js --watch",
+    "dev_standalone": "export MODE='development' && node server",
     "test": "./node_modules/karma/bin/karma start --single-run --no-auto-watch karma.config.js",
     "test_watch": "./node_modules/karma/bin/karma start --auto-watch --no-single-run karma.config.js",
     "lint": "./node_modules/.bin/eslint ."

--- a/scripts/build_dkan.sh
+++ b/scripts/build_dkan.sh
@@ -1,2 +1,0 @@
-export MODE='production'
-webpack --config "$PWD/webpack.config.dkan.js"

--- a/scripts/build_standalone.sh
+++ b/scripts/build_standalone.sh
@@ -1,2 +1,0 @@
-export MODE='production'
-webpack --config "$PWD/webpack.config.standalone.js" --progress

--- a/scripts/dev_dkan.sh
+++ b/scripts/dev_dkan.sh
@@ -1,2 +1,0 @@
-export MODE='development'
-webpack --config "$PWD/webpack.config.dkan.js" --watch

--- a/scripts/dev_standalone.sh
+++ b/scripts/dev_standalone.sh
@@ -1,2 +1,0 @@
-export MODE='development'
-node server

--- a/webpack.config.standalone.js
+++ b/webpack.config.standalone.js
@@ -27,7 +27,7 @@ if(MODE === 'production') {
 module.exports = {
   entry: './src/standalone',
   output: {
-    path: path.join(__dirname, 'dist'),
+    path: path.join(__dirname, 'static'),
     filename: 'bundle.min.js',
     publicPath: '/static/'
   },


### PR DESCRIPTION
… devs can see everything in one place, unless we are trying to hide some real complexity?

Reference to /scripts folder feels like an uneccessary step to understand what the npm commands do.
